### PR TITLE
fix: use valid spreadtab debug directives

### DIFF
--- a/erc-B2/erc-B2.tex
+++ b/erc-B2/erc-B2.tex
@@ -3,7 +3,7 @@
 \input{../erc-common}
 
 \usepackage{spreadtab}
-\STset{debug=true}
+\STset{debug={formula,show tab}}
 \usepackage{fp}
 \FPmessagesfalse
 \usepackage[autolanguage]{numprint}


### PR DESCRIPTION
## Summary
- replace invalid \STset{debug=true} with a documented spreadtab debug configuration
- enable formula diagnostics while keeping the rendered table visible with show tab

## Verification
- latexmk -pdf -interaction=nonstopmode erc-B2.tex